### PR TITLE
fix: broken link

### DIFF
--- a/metadata/COVID19/covid19_poe_design.md
+++ b/metadata/COVID19/covid19_poe_design.md
@@ -6,7 +6,7 @@ Package version: 0.3.1
 
 DHIS2 Version compatibility 2.33.2
 
-Demo: [https://covid19.dhis2.org/](https://covid19.dhis2.org/demo)
+Demo: [https://covid19.dhis2.org/](https://covid19.dhis2.org)
 
 ## Purpose
 


### PR DESCRIPTION
https://covid19.dhis2.org/demo opens a 404 (page not found)
Fixed the link to: https://covid19.dhis2.org