### PR TITLE
refactor: Use verbose option and add raw output from curl to it

### DIFF
--- a/scripts/run-import-tests.sh
+++ b/scripts/run-import-tests.sh
@@ -13,6 +13,6 @@ cat "$file" |
   sed "s/<OU_LEVEL_FACILITY_UID>/${OU_FACILITY_UID:-vFr4zVw6Avn}/g" |
   sed "s/<OU_ROOT_UID>/${OU_ROOT_UID:-GD7TowwI46c}/g" > ./package.json
 
-./api-test.sh -f ./tests.json -url "$url" -auth "$auth" test ou_import
+./api-test.sh -v -f ./tests.json -url "$url" -auth "$auth" test ou_import
 
 URL="$url" AUTH="$auth" ./run-tests.sh

--- a/test/api-test.sh
+++ b/test/api-test.sh
@@ -166,6 +166,12 @@ call_api() {
     API_ERROR=1
     return 1
   fi
+
+  if [[ $VERBOSE -eq 1 ]]; then
+    echo "Raw output:"
+    echo "$raw_output"
+  fi
+
   local header="$(awk -v bl=1 'bl{bl=0; h=($0 ~ /HTTP\//)} /^\r?$/{bl=1} {if(h)print $0 }' <<<"$raw_output")"
   local json=$(jq -c -R -r '. as $line | try fromjson' <<<"$raw_output")
   RESPONSE_BODY=$(sed -n 1p <<<"$json")

--- a/test/run-tests.sh
+++ b/test/run-tests.sh
@@ -25,11 +25,11 @@ if [ -z "$url" ]; then
     exit 1
 fi
 
-if ./api-test.sh -f tests.json -url $url -auth $auth test merge_import; then 
+if ./api-test.sh -v -f tests.json -url $url -auth $auth test merge_import; then
   MERGE_MODE_STATUS="PASSED"
 else 
   MERGE_MODE_STATUS="FAILED"
-  if ./api-test.sh -f tests.json -url $url -auth $auth test replace_import; then 
+  if ./api-test.sh -v -f tests.json -url $url -auth $auth test replace_import; then
     REPLACE_MODE_STATUS="PASSED"
 
   else 


### PR DESCRIPTION
Use the verbose option for the api-test scrip and add the raw output from curl to it, in order to aid troubleshooting when errors occur.

Example:
```
$ ./run-tests.sh

Testing Case: merge_import
Description: Metadata API
Action: POST /api/metadata
BODY_FILE found ./package.json
Raw output:
HTTP/1.1 100 Continue

HTTP/1.1 500 
Server: nginx/1.21.6
Date: Thu, 08 Sep 2022 17:34:26 GMT
Content-Type: application/json;charset=UTF-8
Content-Length: 116
Connection: keep-alive
Set-Cookie: JSESSIONID=4ED5AC329165D91799A81017B4E0299B; Path=/; HttpOnly
Cache-Control: no-cache, private
X-Content-Type-Options: nosniff
X-XSS-Protection: 1; mode=block
X-Frame-Options: SAMEORIGIN

{"httpStatus":"Internal Server Error","httpStatusCode":500,"status":"ERROR","message":"could not execute statement"}
{ "ResponseTime": "31.899394s", "Size": 116 }
...
```