### PR TITLE
refactor: use docker compose instead of d2 to test import

### DIFF
--- a/hack/docker-compose.yml
+++ b/hack/docker-compose.yml
@@ -1,0 +1,30 @@
+version: "3.8"
+
+services:
+  web:
+    image: "${DHIS2_IMAGE:-dhis2/core-dev:local}"
+    ports:
+      - 127.0.0.1:8080:8080
+    volumes:
+      - ./docker/dhis.conf:${DHIS2_HOME:-/DHIS2_home}/dhis.conf
+    environment:
+      DHIS2_HOME: ${DHIS2_HOME:-/DHIS2_home}
+    depends_on:
+      db:
+        condition: service_healthy
+
+  db:
+    image: ghcr.io/baosystems/postgis:12-3.3
+    ports:
+      - 127.0.0.1:5432:5432
+    environment:
+      POSTGRES_USER: dhis
+      POSTGRES_DB: dhis
+      POSTGRES_PASSWORD: &postgres_password dhis
+      PGPASSWORD: *postgres_password # needed by psql in healthcheck
+    healthcheck:
+      test: [ "CMD-SHELL", "psql --no-password --quiet --username $$POSTGRES_USER postgres://127.0.0.1/$$POSTGRES_DB -p 5432 --command \"SELECT 'ok'\" > /dev/null" ]
+      start_period: 120s
+      interval: 1s
+      timeout: 3s
+      retries: 5

--- a/scripts/check-dashboards.sh
+++ b/scripts/check-dashboards.sh
@@ -9,8 +9,8 @@ ou_root="${OU_ROOT_ID:-GD7TowwI46c}"
 
 db_container=$(docker container ls --filter name=db -q)
 
-docker exec -i "$db_container" psql -U dhis -d dhis2 -c "UPDATE dashboard SET sharing = jsonb_set(sharing, '{public}', '\"rw------\"');"
-docker exec -i "$db_container" psql -U dhis -d dhis2 -c "INSERT INTO usermembership (organisationunitid, userinfoid) VALUES ((SELECT organisationunitid FROM organisationunit WHERE uid = '${ou_root}'), (SELECT userinfoid FROM userinfo WHERE code = '${user}'));"
+docker exec -i "$db_container" psql -U dhis -d dhis -c "UPDATE dashboard SET sharing = jsonb_set(sharing, '{public}', '\"rw------\"');"
+docker exec -i "$db_container" psql -U dhis -d dhis -c "INSERT INTO usermembership (organisationunitid, userinfoid) VALUES ((SELECT organisationunitid FROM organisationunit WHERE uid = '${ou_root}'), (SELECT userinfoid FROM userinfo WHERE code = '${user}'));"
 
 echo "{\"dhis\": {\"baseurl\": \"http://localhost:${port}\", \"username\": \"${user}\", \"password\": \"${pass}\"}}" > auth.json
 


### PR DESCRIPTION
There's an issue with the `d2 cluster` tool and the "new" docker images we're building (after version `2.38.2`, `2.39.0`, etc). 

The following two PRs are supposed to fix it, but they are not exactly ready yet:
https://github.com/dhis2/cli/pull/586
https://github.com/dhis2/docker-compose/pull/26

This is a temporary fix to unblock the metadata packages extraction process, until the PRs above are done and merged.