### PR TITLE
refactor: revert to using d2 cluster for testing

### DIFF
--- a/scripts/check-dashboards.sh
+++ b/scripts/check-dashboards.sh
@@ -9,8 +9,8 @@ ou_root="${OU_ROOT_ID:-GD7TowwI46c}"
 
 db_container=$(docker container ls --filter name=db -q)
 
-docker exec -i "$db_container" psql -U dhis -d dhis -c "UPDATE dashboard SET sharing = jsonb_set(sharing, '{public}', '\"rw------\"');"
-docker exec -i "$db_container" psql -U dhis -d dhis -c "INSERT INTO usermembership (organisationunitid, userinfoid) VALUES ((SELECT organisationunitid FROM organisationunit WHERE uid = '${ou_root}'), (SELECT userinfoid FROM userinfo WHERE code = '${user}'));"
+docker exec -i "$db_container" psql -U dhis -d dhis2 -c "UPDATE dashboard SET sharing = jsonb_set(sharing, '{public}', '\"rw------\"');"
+docker exec -i "$db_container" psql -U dhis -d dhis2 -c "INSERT INTO usermembership (organisationunitid, userinfoid) VALUES ((SELECT organisationunitid FROM organisationunit WHERE uid = '${ou_root}'), (SELECT userinfoid FROM userinfo WHERE code = '${user}'));"
 
 echo "{\"dhis\": {\"baseurl\": \"http://localhost:${port}\", \"username\": \"${user}\", \"password\": \"${pass}\"}}" > auth.json
 


### PR DESCRIPTION
This is a revert of https://github.com/dhis2/metadata-package-development/pull/47

`d2 cluster` is now fixed and works with both new and old images, so we can go back to using it for simplicity. 