### PR TITLE
refactor: use packages index spreadsheet for populating parameters

### DIFF
--- a/jenkinsfiles/exporter.Jenkinsfile
+++ b/jenkinsfiles/exporter.Jenkinsfile
@@ -2,8 +2,7 @@
 
 node('ec2-jdk8-large-spot') {
     dir('dhis2-utils') {
-        // TODO Update before merge
-        git url: 'https://github.com/dhis2/dhis2-utils', branch: 'use-argparse-insead-of-envvars'
+        git url: 'https://github.com/dhis2/dhis2-utils'
 
         dir('tools/dhis2-metadata-index-parser') {
             sh 'pip3 install -r requirements.txt'
@@ -34,8 +33,7 @@ pipeline {
         string(name: 'DHIS2_VERSION', defaultValue: '2.38', description: '[OPTIONAL] DHIS2 version to extract the package from. (only major.minor version like 2.38, not 2.38.1, etc)')
         stashedFile(name: 'PACKAGE_FILE_UPLOAD', description: '[OPTIONAL] Upload a package file directly, instead of exporting it.\n If a file is uploaded, all the previous parameters are obsolete.')
         booleanParam(name: 'RUN_CHECKS', defaultValue: true, description: '[OPTIONAL] Choose whether to run the PR expressions and Dashboard checks.')
-        //TODO change to `true` before merging
-        booleanParam(name: 'PUSH_PACKAGE', defaultValue: false, description: '[OPTIONAL] Push the package to its GitHub repository, if the build succeeds.')
+        booleanParam(name: 'PUSH_PACKAGE', defaultValue: true, description: '[OPTIONAL] Push the package to its GitHub repository, if the build succeeds.')
         string(name: 'COMMIT_MESSAGE', defaultValue: '', description: '[OPTIONAL] Custom commit message when pushing package to GitHub.')
     }
 
@@ -86,8 +84,7 @@ pipeline {
                     env.INSTANCE_URL = "${params.INSTANCE_URL != '' ? params.INSTANCE_URL : env.PACKAGE_SOURCE_INSTANCE}"
 
                     dir('dhis2-utils') {
-                        // TODO update before merge
-                        git url: "$UTILS_GIT_URL", branch: 'use-argparse-insead-of-envvars'
+                        git url: "$UTILS_GIT_URL"
                     }
 
                     PACKAGE_IS_EXPORTED = true

--- a/jenkinsfiles/exporter.Jenkinsfile
+++ b/jenkinsfiles/exporter.Jenkinsfile
@@ -2,6 +2,7 @@
 
 node('ec2-jdk8-large-spot') {
     dir('dhis2-utils') {
+        // TODO Update before merge
         git url: 'https://github.com/dhis2/dhis2-utils', branch: 'use-argparse-insead-of-envvars'
 
         dir('tools/dhis2-metadata-index-parser') {
@@ -76,16 +77,17 @@ pipeline {
                     }
 
                     // Get package details based on the selected PACKAGE_NAME parameter value.
-                    env.SELECTED_PACKAGE = sh(returnStdout: true, script: 'echo "$PACKAGES_INDEX_JSON" | jq --arg name "$PACKAGE_NAME" -r \'.[] | select(."Component name" == $name)\'').trim()
-                    env.PACKAGE_CODE = sh(returnStdout: true, script: 'echo "$SELECTED_PACKAGE" | jq -r \'."Extraction code"\'').trim()
-                    env.PACKAGE_TYPE = sh(returnStdout: true, script: 'echo "$SELECTED_PACKAGE" | jq -r \'."Script parameter"\'').trim()
-                    env.PACKAGE_SOURCE_INSTANCE = sh(returnStdout: true, script: 'echo "$SELECTED_PACKAGE" | jq -r \'."Source instance"\'').trim()
-                    env.PACKAGE_HEALTH_AREA_NAME = sh(returnStdout: true, script: 'echo "$SELECTED_PACKAGE" | jq -r \'."Health area"\'').trim()
-                    env.PACKAGE_HEALTH_AREA_CODE = sh(returnStdout: true, script: 'echo "$SELECTED_PACKAGE" | jq -r \'."Health area prefix"\'').trim()
+                    env.SELECTED_PACKAGE = sh(returnStdout: true, script: 'echo "$PACKAGES_INDEX_JSON" | jq --arg name "$PACKAGE_NAME" -r \'.[] | select(."Component Name" == $name)\'').trim()
+                    env.PACKAGE_CODE = sh(returnStdout: true, script: 'echo "$SELECTED_PACKAGE" | jq -r \'."Package Code"\'').trim()
+                    env.PACKAGE_TYPE = sh(returnStdout: true, script: 'echo "$SELECTED_PACKAGE" | jq -r \'."Package Type"\'').trim()
+                    env.PACKAGE_SOURCE_INSTANCE = sh(returnStdout: true, script: 'echo "$SELECTED_PACKAGE" | jq -r \'."Source Instance"\'').trim()
+                    env.PACKAGE_HEALTH_AREA_NAME = sh(returnStdout: true, script: 'echo "$SELECTED_PACKAGE" | jq -r \'."Health Area"\'').trim()
+                    env.PACKAGE_HEALTH_AREA_CODE = sh(returnStdout: true, script: 'echo "$SELECTED_PACKAGE" | jq -r \'."Health Area Code"\'').trim()
                     env.INSTANCE_URL = "${params.INSTANCE_URL != '' ? params.INSTANCE_URL : env.PACKAGE_SOURCE_INSTANCE}"
 
                     dir('dhis2-utils') {
-                        git url: "$UTILS_GIT_URL"
+                        // TODO update before merge
+                        git url: "$UTILS_GIT_URL", branch: 'use-argparse-insead-of-envvars'
                     }
 
                     PACKAGE_IS_EXPORTED = true

--- a/jenkinsfiles/triggerer.Jenkinsfile
+++ b/jenkinsfiles/triggerer.Jenkinsfile
@@ -6,15 +6,10 @@ def generateStagesMap(packages) {
         pkg['Supported DHIS2 Versions'].split(',').each { version ->
             map["${pkg['Package Code']} (type: ${pkg['Package Type']}) for ${version}"] = {
                 stage("Export package") {
-                    // TODO update before merge
-                    build job: 'test-metadata-exporter-v2', propagate: false, parameters: [
+                    build job: 'metadata-exporter', propagate: false, parameters: [
                         string(name: 'DHIS2_VERSION', value: "$version"),
                         string(name: 'INSTANCE_URL', value: "${pkg['Source Instance']}"),
                         string(name: 'PACKAGE_NAME', value: "${pkg['Component Name']}"),
-//                        string(name: 'Package_type', value: "${pkg['Script parameter']}"),
-//                        string(name: 'Package_description', value: "${pkg['Component Name']}"),
-//                        string(name: 'Package_health_area_name', value: "${pkg['Health area']}"),
-//                        string(name: 'Package_health_area_code', value: "${pkg['Health area prefix']}"),
                     ]
                 }
             }
@@ -47,7 +42,7 @@ pipeline {
             steps {
                 script {
                     dir('dhis2-utils') {
-                        git url: 'https://github.com/dhis2/dhis2-utils', branch: 'use-argparse-insead-of-envvars'
+                        git url: 'https://github.com/dhis2/dhis2-utils'
 
                         dir('tools/dhis2-metadata-index-parser') {
                             sh 'pip3 install -r requirements.txt'

--- a/jenkinsfiles/triggerer.Jenkinsfile
+++ b/jenkinsfiles/triggerer.Jenkinsfile
@@ -3,17 +3,18 @@ def generateStagesMap(packages) {
     def map = [:]
 
     packages.each { pkg ->
-        pkg["DHIS2 versions to export from"].split(',').each { version ->
-            map["${pkg['Extraction code']} (type: ${pkg['Script parameter']}) for ${version}"] = {
+        pkg['Supported DHIS2 Versions'].split(',').each { version ->
+            map["${pkg['Package Code']} (type: ${pkg['Package Type']}) for ${version}"] = {
                 stage("Export package") {
-                    build job: 'metadata-exporter', propagate: false, parameters: [
-                        string(name: 'DHIS2_version', value: "$version"),
-                        string(name: 'Instance_url', value: "${pkg['Source instance']}"),
-                        string(name: 'Package_code', value: "${pkg['Extraction code']}"),
-                        string(name: 'Package_type', value: "${pkg['Script parameter']}"),
-                        string(name: 'Package_description', value: "${pkg['Component name']}"),
-                        string(name: 'Package_health_area_name', value: "${pkg['Health area']}"),
-                        string(name: 'Package_health_area_code', value: "${pkg['Health area prefix']}"),
+                    // TODO update before merge
+                    build job: 'test-metadata-exporter-v2', propagate: false, parameters: [
+                        string(name: 'DHIS2_VERSION', value: "$version"),
+                        string(name: 'INSTANCE_URL', value: "${pkg['Source Instance']}"),
+                        string(name: 'PACKAGE_NAME', value: "${pkg['Component Name']}"),
+//                        string(name: 'Package_type', value: "${pkg['Script parameter']}"),
+//                        string(name: 'Package_description', value: "${pkg['Component Name']}"),
+//                        string(name: 'Package_health_area_name', value: "${pkg['Health area']}"),
+//                        string(name: 'Package_health_area_code', value: "${pkg['Health area prefix']}"),
                     ]
                 }
             }
@@ -39,19 +40,22 @@ pipeline {
     stages {
         stage('Get Enabled Packages') {
             environment {
-                GC_SERVICE_ACCOUNT_FILE = credentials('metadata-index-parser-service-account')
+                GOOGLE_SERVICE_ACCOUNT = credentials('metadata-index-parser-service-account')
                 GOOGLE_SPREADSHEET_ID = '1IIQL2IkGJqiIWLr6Bgg7p9fE78AwQYhHBNGoV-spGOM'
             }
 
             steps {
                 script {
                     dir('dhis2-utils') {
-                        git url: 'https://github.com/dhis2/dhis2-utils'
+                        git url: 'https://github.com/dhis2/dhis2-utils', branch: 'use-argparse-insead-of-envvars'
 
                         dir('tools/dhis2-metadata-index-parser') {
                             sh 'pip3 install -r requirements.txt'
 
-                            INPUT_JSON = sh(returnStdout: true, script: 'python3 parse-index.py').trim()
+                            INPUT_JSON = sh(
+                                returnStdout: true,
+                                script: 'python3 parse-index.py --service-account-file $GOOGLE_SERVICE_ACCOUNT --spreadsheet-id $GOOGLE_SPREADSHEET_ID'
+                            ).trim()
 
                             packagesList = readJSON text: "$INPUT_JSON"
                         }

--- a/scripts/export-package.sh
+++ b/scripts/export-package.sh
@@ -9,12 +9,13 @@ health_area_name="$4"
 health_area_code="$5"
 export_instance="$6"
 
-if [[ "${DHIS2_version:-}" == "2.38" || -z "${DHIS2_version:-}" || "${DHIS2_version:-}" =~ [0-9] ]]; then
-  instance="$export_instance"
-else
-  instance="https://who-dev.dhis2.org/${export_instance##*/}${DHIS2_version//./}"
+base_dhis2_version='2.38'
+higher_dhis2_versions_server='https://who-dev.dhis2.org'
+
+if [[ "${DHIS2_VERSION:-}" != "$base_dhis2_version" && -n "${DHIS2_VERSION:-}" ]]; then
+  export_instance="${higher_dhis2_versions_server}/${export_instance##*/}${DHIS2_VERSION//./}"
 fi
 
 pip3 install -r dhis2-utils/tools/dhis2-package-exporter/requirements.txt
 
-python3 -u dhis2-utils/tools/dhis2-package-exporter/package_exporter.py "$type" "$code" "$code" -desc="$description" -han="$health_area_name" -hac="$health_area_code" -i="$instance"
+python3 -u dhis2-utils/tools/dhis2-package-exporter/package_exporter.py "$type" "$code" "$code" -desc="$description" -han="$health_area_name" -hac="$health_area_code" -i="$export_instance"

--- a/scripts/push-package.sh
+++ b/scripts/push-package.sh
@@ -36,8 +36,8 @@ if [[ "$package_type" == "$dashboard_package_type" ]]; then
   commit_message="$commit_message ($dashboard_package_type)"
 fi
 
-if [[ "${Commit_message:-}" ]]; then
-  commit_message="${Commit_message}"
+if [[ "${COMMIT_MESSAGE:-}" ]]; then
+  commit_message="${COMMIT_MESSAGE}"
 fi
 
 git config --global user.email "$GITHUB_EMAIL"


### PR DESCRIPTION
This PR simplifies the Exporter pipeline parameters UI by using the [Packages index spreadsheet (aka "Input index")](https://docs.google.com/spreadsheets/d/1IIQL2IkGJqiIWLr6Bgg7p9fE78AwQYhHBNGoV-spGOM/edit?pli=1#gid=1314443450) to populate the `PACKAGE_NAME` parameter and get the rest of the required parameters for extracting a package based on the user selection.